### PR TITLE
WIP - Add cellFormat, timeZone, and userLocale Airtable API params

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -282,6 +282,15 @@ have a corresponding ``kwargs`` that can be used with fetching methods like :met
    * - ``fields``
      - ``fields``
      - |kwarg_fields|
+   * - ``cell_format``
+     - ``cellFormat``
+     - |kwarg_cell_format|
+   * - ``user_locale``
+     - ``userLocale``
+     - |kwarg_user_locale|
+   * - ``time_zone``
+     - ``timeZone``
+     - |kwarg_time_zone|
 
 
 Formulas

--- a/docs/source/substitutions.rst
+++ b/docs/source/substitutions.rst
@@ -48,3 +48,19 @@
 
 .. |kwarg_typecast| replace:: The Airtable API will perform best-effort
     automatic data conversion from string values. Default is False.
+
+.. |kwarg_cell_format| replace:: The cell format to request from the Airtable
+    API. Supported options are `json` (the default) and `string`. 
+    `json` will return cells as a JSON object. `string` will return
+    the cell as a string. `user_locale` and `time_zone` must be set when using
+    `string`.
+
+.. |kwarg_user_locale| replace:: The user locale that should be used to format
+    dates when using `string` as the `cell_format`. See
+    https://support.airtable.com/hc/en-us/articles/220340268-Supported-locale-modifiers-for-SET-LOCALE
+    for valid values.
+
+.. |kwarg_time_zone| replace:: The time zone that should be used to format dates
+    when using `string` as the `cell_format`. See
+    https://support.airtable.com/hc/en-us/articles/216141558-Supported-timezones-for-SET-TIMEZONE
+    for valid values.

--- a/pyairtable/api/api.py
+++ b/pyairtable/api/api.py
@@ -94,6 +94,9 @@ class Api(ApiAbstract):
             fields: |kwarg_fields|
             sort: |kwarg_sort|
             formula: |kwarg_formula|
+            cell_format: |kwarg_cell_format|
+            user_locale: |kwarg_user_locale|
+            time_zone: |kwarg_time_zone|
 
         Returns:
             iterator: Record Iterator, grouped by page size
@@ -142,6 +145,9 @@ class Api(ApiAbstract):
             fields: |kwarg_fields|
             sort: |kwarg_sort|
             formula: |kwarg_formula|
+            cell_format: |kwarg_cell_format|
+            user_locale: |kwarg_user_locale|
+            time_zone: |kwarg_time_zone|
 
         Returns:
             records (``list``): List of Records

--- a/pyairtable/api/params.py
+++ b/pyairtable/api/params.py
@@ -67,7 +67,6 @@ def field_names_to_sorting_dict(field_names: List[str]) -> List[Dict[str, str]]:
 
 def to_params_dict(param_name: str, value: Any):
     """Returns a dictionary for use in Request 'params'"""
-    # TODO: timeZone, userLocale
     if param_name == "max_records":
         return {"maxRecords": value}
     elif param_name == "view":
@@ -80,6 +79,12 @@ def to_params_dict(param_name: str, value: Any):
         return {"filterByFormula": value}
     elif param_name == "fields":
         return {"fields[]": value}
+    elif param_name == "cell_format":
+        return {"cellFormat": value}
+    elif param_name == "time_zone":
+        return {"timeZone": value}
+    elif param_name == "user_locale":
+        return {"userLocale": value}
     elif param_name == "sort":
         sorting_dict_list = field_names_to_sorting_dict(value)
         return dict_list_to_request_params("sort", sorting_dict_list)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -89,6 +89,14 @@ def test_params_integration(table, mock_records, mock_response_iterator):
             "?sort%5B0%5D%5Bdirection%5D=asc&sort%5B0%5D%5Bfield%5D=Name&sort%5B1%5D%5Bdirection%5D=desc&sort%5B1%5D%5Bfield%5D=Phone",
             # '?sort[0][direction]=desc&sort[0][field]=Name&sort[1][direction]=desc&sort[1][field]=Phone'
         ],
+        ["cell_format", "string", "?cellFormat=string"],
+        ["user_locale", "en-US", "?userLocale=en-US"],
+        [
+            "time_zone",
+            "America/Chicago",
+            "?timeZone=America%2FChicago"
+            # '?timeZone=America/Chicago'
+        ],
         # TODO
         # [
         #     {"sort": [("Name", "desc"), ("Phone", "asc")]},


### PR DESCRIPTION
Add `cellFormat` (and `timeZone` / `userLocale` param support) 